### PR TITLE
QOL Changes

### DIFF
--- a/src/generated/resources/data/minecraft/tags/blocks/leaves.json
+++ b/src/generated/resources/data/minecraft/tags/blocks/leaves.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "sushigocrafting:avocado_leaves"
+  ]
+}

--- a/src/main/java/com/buuz135/sushigocrafting/SushiGoCrafting.java
+++ b/src/main/java/com/buuz135/sushigocrafting/SushiGoCrafting.java
@@ -10,6 +10,7 @@ import com.buuz135.sushigocrafting.client.ClientProxy;
 import com.buuz135.sushigocrafting.datagen.*;
 import com.buuz135.sushigocrafting.item.FoodItem;
 import com.buuz135.sushigocrafting.network.CapabilitySyncMessage;
+import com.buuz135.sushigocrafting.proxy.SushiCompostables;
 import com.buuz135.sushigocrafting.proxy.SushiContent;
 import com.buuz135.sushigocrafting.tile.machinery.*;
 import com.buuz135.sushigocrafting.world.SushiTab;
@@ -168,6 +169,7 @@ public class SushiGoCrafting extends ModuleController {
         SpawnPlacements.register(SushiContent.EntityTypes.TUNA.get(), SpawnPlacements.Type.IN_WATER, Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, AbstractFish::checkMobSpawnRules);
         Holder<ConfiguredFeature<NoneFeatureConfiguration, ?>> CONFIGURED_SEAWEED = FeatureUtils.register("sushigocrafting:seaweed", SushiContent.Features.SEAWEED.get());
         Holder<PlacedFeature> PLACED_SEAWEED = PlacementUtils.register("sushigocrafting:seaweed", CONFIGURED_SEAWEED, NoiseBasedCountPlacement.of(120, 80.0D, 0.0D), InSquarePlacement.spread(), PlacementUtils.HEIGHTMAP_TOP_SOLID, BiomeFilter.biome());
+        SushiCompostables.init();
     }
 
     public void dataGen(GatherDataEvent event) {

--- a/src/main/java/com/buuz135/sushigocrafting/datagen/SushiBlockTagsProvider.java
+++ b/src/main/java/com/buuz135/sushigocrafting/datagen/SushiBlockTagsProvider.java
@@ -20,6 +20,7 @@ public class SushiBlockTagsProvider extends BlockTagsProvider {
         tag(BlockTags.LOGS).add(SushiContent.Blocks.AVOCADO_LOG.get());
         tag(BlockTags.LOGS).add(SushiContent.Blocks.AVOCADO_LEAVES_LOG.get());
         tag(BlockTags.SAPLINGS).add(SushiContent.Blocks.AVOCADO_SAPLING.get());
+        tag(BlockTags.LEAVES).add(SushiContent.Blocks.AVOCADO_LEAVES.get());
         for (CustomCropBlock block : new CustomCropBlock[]{SushiContent.Blocks.RICE_CROP.get(), SushiContent.Blocks.CUCUMBER_CROP.get(), SushiContent.Blocks.SOY_CROP.get(), SushiContent.Blocks.WASABI_CROP.get(), SushiContent.Blocks.SESAME_CROP.get()}) {
             tag(BlockTags.CROPS).add(block);
             tag(BlockTags.BEE_GROWABLES).add(block);

--- a/src/main/java/com/buuz135/sushigocrafting/item/AmountItem.java
+++ b/src/main/java/com/buuz135/sushigocrafting/item/AmountItem.java
@@ -136,4 +136,13 @@ public class AmountItem extends SushiItem {
         return stack;
     }
 
+    public static ItemStack combineStacks(ItemStack first, ItemStack second) {
+        if (!first.is(second.getItem())) return null;
+        if (first.getItem() instanceof AmountItem firstAmount && second.getItem() instanceof AmountItem secondAmount) {
+            first.getOrCreateTag().putInt(NBT_AMOUNT, Math.min(firstAmount.getMaxCombineAmount(), firstAmount.getCurrentAmount(first) + secondAmount.getCurrentAmount(second)));
+            return first;
+        }
+        return null;
+    }
+
 }

--- a/src/main/java/com/buuz135/sushigocrafting/proxy/SushiCompostables.java
+++ b/src/main/java/com/buuz135/sushigocrafting/proxy/SushiCompostables.java
@@ -1,0 +1,42 @@
+package com.buuz135.sushigocrafting.proxy;
+
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.ComposterBlock;
+import net.minecraftforge.registries.RegistryObject;
+
+public class SushiCompostables {
+
+
+    public static void init() {
+        register(0.3F,
+                SushiContent.Items.RICE_SEEDS,
+                SushiContent.Items.CUCUMBER_SEEDS,
+                SushiContent.Items.SOY_SEEDS,
+                SushiContent.Items.WASABI_SEEDS,
+                SushiContent.Items.SESAME_SEEDS,
+                SushiContent.Items.AVOCADO_LEAVES,
+                SushiContent.Items.AVOCADO_SAPLING,
+                SushiContent.Items.SEAWEED
+        );
+        register(0.5F,
+                SushiContent.Items.SEAWEED_BLOCK
+        );
+        register(0.65F,
+                SushiContent.Items.AVOCADO,
+                SushiContent.Items.CUCUMBER,
+                SushiContent.Items.SOY_BEAN,
+                SushiContent.Items.WASABI_ROOT
+        );
+    }
+
+    @SafeVarargs
+    private static void register(float chance, RegistryObject<? extends ItemLike>... items) {
+        for (RegistryObject<? extends ItemLike> item : items) {
+            register(item.get(), chance);
+        }
+    }
+
+    private static void register(ItemLike item, float chance) {
+        ComposterBlock.COMPOSTABLES.put(item, chance);
+    }
+}


### PR DESCRIPTION
## This PR does 3 things
- Makes it so the fermentation barrel works like the rice cooker and combines stacks when a recipe outputs a stack that is of the same type as is already in the output.
- Added all crops, crop outputs, and leaves to the composter which resolves #15 
- Added leaves to leaves tag which also resolves #18 

### Notes
Your data generator is kind of broken I ran it and it did output files but it also deleted all the types for the sushi so I rollbacked everything besides the one leaves tag I added.