### PR TITLE
[Feature] PistonCrafting with Tags

### DIFF
--- a/src/main/java/com/buuz135/sushigocrafting/SushiGoCrafting.java
+++ b/src/main/java/com/buuz135/sushigocrafting/SushiGoCrafting.java
@@ -10,6 +10,7 @@ import com.buuz135.sushigocrafting.item.SushiDataComponent;
 import com.buuz135.sushigocrafting.network.CapabilitySyncMessage;
 import com.buuz135.sushigocrafting.proxy.SushiContent;
 import com.buuz135.sushigocrafting.tile.machinery.*;
+import com.buuz135.sushigocrafting.world.PistonCrafting;
 import com.hrznstudio.titanium.block.tile.ActiveTile;
 import com.hrznstudio.titanium.event.handler.EventManager;
 import com.hrznstudio.titanium.module.ModuleController;
@@ -97,26 +98,7 @@ public class SushiGoCrafting extends ModuleController {
         NBTManager.getInstance().scanTileClassForAnnotations(CuttingBoardTile.class);
         NBTManager.getInstance().scanTileClassForAnnotations(CoolerBoxTile.class);
         NBTManager.getInstance().scanTileClassForAnnotations(FermentationBarrelTile.class);
-        EventManager.forge(PistonEvent.Pre.class).process(pre -> {
-            if (pre.getLevel().getBlockState(pre.getPos().relative(pre.getDirection(), 2)).getBlock().equals(Blocks.IRON_BLOCK)) {
-                NonNullList<ItemStack> list = NonNullList.create();
-                var level = pre.getLevel();
-                var aabb = new AABB(pre.getPos().relative(pre.getDirection(), 1));
-                var entities = level.getEntitiesOfClass(ItemEntity.class, aabb, EntitySelector.ENTITY_STILL_ALIVE);
-                for (ItemEntity entity : entities) {
-                    if (entity.getItem().is(Items.DRIED_KELP_BLOCK)) {
-                        list.add(new ItemStack(SushiContent.Items.NORI_SHEET.get(), (5 + pre.getLevel().getRandom().nextInt(4)) * entity.getItem().getCount()));
-                        entity.remove(Entity.RemovalReason.KILLED);
-                    }
-                }
-                if (!list.isEmpty()) {
-                    if (level instanceof ServerLevel serverLevel) {
-                        serverLevel.playSeededSound(null, pre.getPos().getX(), pre.getPos().getY(), pre.getPos().getZ(), SoundEvents.ANVIL_LAND, SoundSource.BLOCKS, 0.75f, 1f, serverLevel.random.nextLong());
-                    }
-                    Containers.dropContents((Level) pre.getLevel(), pre.getFaceOffsetPos().offset(0, 0, 0), list);
-                }
-            }
-        }).subscribe();
+        new PistonCrafting();
         EventManager.mod(EntityAttributeCreationEvent.class).process(entityAttributeCreationEvent -> {
             entityAttributeCreationEvent.put(SushiContent.EntityTypes.TUNA.get(), AbstractFish.createAttributes().build());
             entityAttributeCreationEvent.put(SushiContent.EntityTypes.SHRIMP.get(), AbstractFish.createAttributes().build());

--- a/src/main/java/com/buuz135/sushigocrafting/proxy/SushiContent.java
+++ b/src/main/java/com/buuz135/sushigocrafting/proxy/SushiContent.java
@@ -27,6 +27,8 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.sounds.SoundEvents;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagKey;
 import net.minecraft.world.effect.MobEffect;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -56,6 +58,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
 import java.util.function.Supplier;
+
+import static com.buuz135.sushigocrafting.SushiGoCrafting.MOD_ID;
 
 public class SushiContent {
 
@@ -285,5 +289,10 @@ public class SushiContent {
                     }
                 })
                 .build());
+    }
+
+    public static class Tags {
+        public static final TagKey<Block> PRESSING_BASE = BlockTags.create(ResourceLocation.tryBuild(MOD_ID, "pressing_base"));
+
     }
 }

--- a/src/main/java/com/buuz135/sushigocrafting/world/PistonCrafting.java
+++ b/src/main/java/com/buuz135/sushigocrafting/world/PistonCrafting.java
@@ -1,0 +1,54 @@
+package com.buuz135.sushigocrafting.world;
+
+import com.buuz135.sushigocrafting.proxy.SushiContent;
+import com.hrznstudio.titanium.event.handler.EventManager;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.NonNullList;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.sounds.SoundEvents;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.Containers;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntitySelector;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.neoforged.neoforge.event.level.PistonEvent;
+import static com.buuz135.sushigocrafting.SushiGoCrafting.MOD_ID;
+
+public class PistonCrafting {
+
+    public PistonCrafting(){
+        EventManager.forge(PistonEvent.Pre.class).process(pre -> {
+            BlockPos targetPos = pre.getPos().relative(pre.getDirection(), 2);
+            BlockState targetBlockState = pre.getLevel().getBlockState(targetPos);
+
+            if(targetBlockState.is(SushiContent.Tags.PRESSING_BASE)){
+                NonNullList<ItemStack> list = NonNullList.create();
+                var level = pre.getLevel();
+                var aabb = new AABB(pre.getPos().relative(pre.getDirection(), 1));
+                var entities = level.getEntitiesOfClass(ItemEntity.class, aabb, EntitySelector.ENTITY_STILL_ALIVE);
+                for (ItemEntity entity : entities) {
+                    if (entity.getItem().is(Items.DRIED_KELP_BLOCK)) {
+                        list.add(new ItemStack(SushiContent.Items.NORI_SHEET.get(), (5 + pre.getLevel().getRandom().nextInt(4)) * entity.getItem().getCount()));
+                        entity.remove(Entity.RemovalReason.KILLED);
+                    }
+                }
+                if (!list.isEmpty()) {
+                    if (level instanceof ServerLevel serverLevel) {
+                        serverLevel.playSeededSound(null, pre.getPos().getX(), pre.getPos().getY(), pre.getPos().getZ(), SoundEvents.ANVIL_LAND, SoundSource.BLOCKS, 0.75f, 1f, serverLevel.random.nextLong());
+                    }
+                    Containers.dropContents((Level) pre.getLevel(), pre.getFaceOffsetPos().offset(0, 0, 0), list);
+                }
+            }
+        }).subscribe();
+    }
+}

--- a/src/main/resources/data/sushigocrafting/tags/block/pressing_base.json
+++ b/src/main/resources/data/sushigocrafting/tags/block/pressing_base.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "minecraft:cobblestone"
+  ]
+}

--- a/src/main/resources/data/sushigocrafting/tags/block/pressing_base.json
+++ b/src/main/resources/data/sushigocrafting/tags/block/pressing_base.json
@@ -1,5 +1,5 @@
 {
   "values": [
-    "minecraft:cobblestone"
+    "minecraft:iron_block"
   ]
 }


### PR DESCRIPTION
**PR Message:**  
Refactored Pistoncrafting interactions in SushiGoCrafting

- Moved Pistoncrafting world interactions to a dedicated class.  
- Replaced the hardcoded base block with a tag, giving pack developers the flexibility to define their own base blocks.  

